### PR TITLE
Add token usage visualization bar to script page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1151,3 +1151,137 @@ main > section:last-child li:focus-within .script-actions {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.6; }
 }
+
+/* Token usage bar */
+.token-usage {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border: 1px solid;
+  border-radius: 8px;
+}
+
+[data-theme="dark"] .token-usage {
+  border-color: #333;
+  background-color: #2a2a2a;
+}
+
+[data-theme="light"] .token-usage {
+  border-color: #e5e5e5;
+  background-color: #f9f9f9;
+}
+
+.token-usage-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.7;
+}
+
+.token-usage-bar {
+  display: flex;
+  height: 24px;
+  border-radius: 4px;
+  overflow: hidden;
+  gap: 1px;
+}
+
+[data-theme="dark"] .token-usage-bar {
+  background-color: #1a1a1a;
+}
+
+[data-theme="light"] .token-usage-bar {
+  background-color: #e5e5e5;
+}
+
+.token-usage-segment {
+  position: relative;
+  min-width: 4px;
+  cursor: default;
+  transition: opacity 0.15s ease;
+}
+
+.token-usage-segment:hover {
+  opacity: 0.85;
+}
+
+.token-usage-segment[data-role="system"] {
+  background-color: #6366f1;
+}
+
+.token-usage-segment[data-role="user"] {
+  background-color: #4f46e5;
+}
+
+.token-usage-segment[data-role="assistant"][data-direction="response"] {
+  background-color: #10b981;
+}
+
+.token-usage-segment[data-role="assistant"][data-direction="prompt"] {
+  background-color: #34d399;
+}
+
+.token-usage-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  z-index: 10;
+  pointer-events: none;
+}
+
+[data-theme="dark"] .token-usage-tooltip {
+  background-color: #333;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="light"] .token-usage-tooltip {
+  background-color: #1a1a1a;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.token-usage-segment:hover .token-usage-tooltip {
+  display: block;
+}
+
+.token-usage-legend {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+.token-usage-legend span::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  margin-right: 0.375rem;
+  vertical-align: middle;
+}
+
+.token-usage-legend span[data-role="system"]::before {
+  background-color: #6366f1;
+}
+
+.token-usage-legend span[data-role="user"]::before {
+  background-color: #4f46e5;
+}
+
+.token-usage-legend span[data-role="assistant"]::before {
+  background-color: #10b981;
+}

--- a/src/components/TokenUsageBar.tsx
+++ b/src/components/TokenUsageBar.tsx
@@ -1,0 +1,112 @@
+import { estimateTokenCount } from '../utils/contextWindow'
+import type { RawConversation } from '../types/conversation'
+
+interface TokenSegment {
+  role: 'system' | 'user' | 'assistant'
+  kind: string
+  tokens: number
+  direction: 'prompt' | 'response'
+}
+
+function classifyMessage(
+  role: 'system' | 'user' | 'assistant',
+  messageIndex: number,
+  totalMessages: number,
+  generationIndex: number
+): { kind: string; direction: 'prompt' | 'response' } {
+  if (role === 'system') {
+    return { kind: 'System prompt', direction: 'prompt' }
+  }
+  if (role === 'assistant') {
+    return { kind: 'Prior response (history)', direction: 'response' }
+  }
+  // user role
+  if (generationIndex === 0) {
+    return { kind: 'User prompt + outline request', direction: 'prompt' }
+  }
+  if (messageIndex === totalMessages - 1) {
+    return { kind: 'Section request', direction: 'prompt' }
+  }
+  return { kind: 'User prompt', direction: 'prompt' }
+}
+
+function buildSegments(conversation: RawConversation): TokenSegment[] {
+  if (conversation.generations.length === 0) return []
+
+  const latest = conversation.generations[conversation.generations.length - 1]
+  const segments: TokenSegment[] = []
+
+  for (let i = 0; i < latest.messages.length; i++) {
+    const msg = latest.messages[i]
+    const tokens = estimateTokenCount(msg.content)
+    const { kind, direction } = classifyMessage(
+      msg.role,
+      i,
+      latest.messages.length,
+      conversation.generations.length - 1
+    )
+    segments.push({ role: msg.role, kind, tokens, direction })
+  }
+
+  if (latest.response) {
+    segments.push({
+      role: 'assistant',
+      kind: 'Current response',
+      tokens: estimateTokenCount(latest.response),
+      direction: 'response'
+    })
+  }
+
+  return segments
+}
+
+interface TokenUsageBarProps {
+  conversation: RawConversation | undefined
+}
+
+export const TokenUsageBar = ({ conversation }: TokenUsageBarProps) => {
+  if (!conversation || conversation.generations.length === 0) return null
+
+  const segments = buildSegments(conversation)
+  const totalTokens = segments.reduce((sum, s) => sum + s.tokens, 0)
+
+  if (totalTokens === 0) return null
+
+  return (
+    <aside aria-label="Token usage breakdown" className="token-usage">
+      <div className="token-usage-header">
+        <span>Context tokens</span>
+        <span>{totalTokens.toLocaleString()} estimated</span>
+      </div>
+      <div className="token-usage-bar">
+        {segments.map((segment, i) => {
+          const widthPercent = (segment.tokens / totalTokens) * 100
+          if (widthPercent < 0.5) return null
+          return (
+            <div
+              key={i}
+              className="token-usage-segment"
+              data-role={segment.role}
+              data-direction={segment.direction}
+              style={{ width: `${widthPercent}%` }}
+              aria-label={`${segment.kind}: ${segment.tokens.toLocaleString()} tokens`}
+            >
+              <span className="token-usage-tooltip">
+                <strong>{segment.direction === 'prompt' ? 'Prompt' : 'Response'}</strong>
+                <br />
+                {segment.kind}
+                <br />
+                {segment.tokens.toLocaleString()} tokens ({Math.round(widthPercent)}%)
+              </span>
+            </div>
+          )
+        })}
+      </div>
+      <div className="token-usage-legend">
+        <span data-role="system">System</span>
+        <span data-role="user">User</span>
+        <span data-role="assistant">Assistant</span>
+      </div>
+    </aside>
+  )
+}

--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -2,6 +2,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { ArrowLeft, RotateCcw } from 'lucide-react'
 import { useAppContext } from '../hooks/useAppContext'
 import { useConversationContext } from '../hooks/useConversationContext'
+import { TokenUsageBar } from '../components/TokenUsageBar'
 import type { Script } from '../types/script'
 import type { RawConversation } from '../types/conversation'
 
@@ -334,6 +335,8 @@ export const ScriptPage = ({ showSectionTitles = true }: ScriptPageProps) => {
         sections={document.sections}
         generationMachine={isThisConversation ? generationMachine : null}
       />
+
+      <TokenUsageBar conversation={conversation} />
 
       <article>
         {document.sections.length > 0 ? (


### PR DESCRIPTION
## Summary
This PR adds a visual token usage breakdown component that displays how tokens are distributed across different parts of the conversation context (system prompts, user messages, assistant responses).

## Key Changes
- **New Component**: `TokenUsageBar.tsx` - Displays an interactive bar chart showing token distribution across conversation segments
  - Segments messages by role (system, user, assistant) and direction (prompt vs response)
  - Classifies messages by type (e.g., "System prompt", "User prompt", "Current response")
  - Estimates token counts using the existing `estimateTokenCount` utility
  - Shows tooltips on hover with detailed breakdown (token count, percentage, classification)
  
- **Styling**: Added comprehensive CSS for the token usage component
  - Responsive bar visualization with color-coded segments
  - Dark/light theme support
  - Interactive hover states with smooth transitions
  - Legend showing color mapping for system/user/assistant roles
  
- **Integration**: Integrated `TokenUsageBar` into `ScriptPage` to display token usage for the current conversation

## Implementation Details
- The component only renders if a conversation exists with generations
- Segments smaller than 0.5% of total tokens are hidden to avoid visual clutter
- Token counts are estimated using the existing context window utility
- Uses semantic HTML with proper ARIA labels for accessibility
- Tooltips display both absolute token counts and percentages for context

https://claude.ai/code/session_01XPRhdQbgLbmZb2z746GjA7